### PR TITLE
Use `main` branch instead of `master`

### DIFF
--- a/autoload/tldr.vim
+++ b/autoload/tldr.vim
@@ -157,14 +157,14 @@ fu! tldr#update_docs()
       silent exec '!powershell -c "Expand-Archive -Path ''' . expand(g:tldr_saved_zip_path)
       \ . ''' -DestinationPath  ''' . expand("~/.cache/") . '''"'
       silent exec '!del /S /F "' . expand(g:tldr_saved_zip_path) . '"'
-      silent exec '!move /Y ' . expand("~/.cache/tldr-master") . ' '
+      silent exec '!move /Y ' . expand("~/.cache/tldr-main") . ' '
       \ . expand(g:tldr_directory_path)
     else
       silent exec '!curl -fLo ' . g:tldr_saved_zip_path . ' --create-dirs '
       \ . g:tldr_source_zip_url
       silent exec '!unzip -o -d ~/.cache/ ' . g:tldr_saved_zip_path
       silent exec '!rm -rf ' . g:tldr_saved_zip_path
-      silent exec '!mv ~/.cache/tldr-master ' . g:tldr_directory_path
+      silent exec '!mv ~/.cache/tldr-main ' . g:tldr_directory_path
     endif
 
     call s:Print("Now tldr docs is updated!")

--- a/doc/tldr.txt
+++ b/doc/tldr.txt
@@ -51,7 +51,7 @@ Use this to change the temporary location for downloading zip: >
                                                       *'g:tldr_source_zip_url'*
 Change this to set the tldr source zip url: >
   let g:tldr_source_zip_url =
-   \ 'https://github.com/tldr-pages/tldr/archive/master.zip'
+   \ 'https://github.com/tldr-pages/tldr/archive/main.zip'
 <
 
                                                   *'g:tldr_enabled_categories'*

--- a/plugin/tldr.vim
+++ b/plugin/tldr.vim
@@ -33,7 +33,7 @@ endif
 
 if !exists("g:tldr_source_zip_url")
   let g:tldr_source_zip_url =
-        \ "https://github.com/tldr-pages/tldr/archive/master.zip"
+        \ "https://github.com/tldr-pages/tldr/archive/main.zip"
 endif
 
 if !exists("g:tldr_enabled_categories")


### PR DESCRIPTION
[About 1.5 years ago](https://github.com/tldr-pages/tldr/discussions/5868), we deprecated the master branch in favour of the main branch. We intend to remove it [soon, likely by May 1st 2023](https://github.com/tldr-pages/tldr/issues/9628).